### PR TITLE
fix :

### DIFF
--- a/src/main/java/com/example/foodthought/repository/CommentRepository.java
+++ b/src/main/java/com/example/foodthought/repository/CommentRepository.java
@@ -6,7 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByBoardId(Long boardId);
+//    List<Comment> findByBoardId(Long boardId);
+    List<Comment> findByBoardIdAndParentCommentIsNull(Long boardId);
 
     List<Comment> findCommentsByBoard_Id(Long boardId);
 }

--- a/src/main/java/com/example/foodthought/service/CommentService.java
+++ b/src/main/java/com/example/foodthought/service/CommentService.java
@@ -48,7 +48,7 @@ public class CommentService {
     // 댓글, 대댓글 조회
     public List<CommentResponse> getComment(Long boardId) {
         findBoard(boardId);
-        List<Comment> commentList = commentRepository.findByBoardId(boardId);
+        List<Comment> commentList = commentRepository.findByBoardIdAndParentCommentIsNull(boardId);
         return convertToDtoList(commentList);
     }
 
@@ -141,7 +141,7 @@ public class CommentService {
     // admin 댓글 조회 (block 된 게시물까지 전부 출력)
     public List<CommentResponse> getAllComment(Long boardId) {
         findBoard(boardId);
-        List<Comment> commentList = commentRepository.findByBoardId(boardId);
+        List<Comment> commentList = commentRepository.findByBoardIdAndParentCommentIsNull(boardId);
         return AdminConvertToDtoList(commentList);
     }
 


### PR DESCRIPTION
CommentRepository.java 에서 findByBoardId 대신 findByBoardIdAndParentCommentIsNull 을 사용해 BoardService 의 댓글 조회 로직에서 대댓글이 두 번 조회되는 오류 해결.